### PR TITLE
Make the dirtydb fix backwards compatible.

### DIFF
--- a/scripts/start_node.sh
+++ b/scripts/start_node.sh
@@ -3,7 +3,7 @@
 # 1 - data directory
 # 2 - config.ini directory
 # 3 - snapshot
-# 4 - replay-blockchain option
-# 5 - node name
+# 4 - node name
+# 5 - replay-blockchain option
 
-nodeos --data-dir=$1 --config-dir=$2 $3 $4 >/app/$5.out 2>&1 &
+nodeos --data-dir=$1 --config-dir=$2 $3 $5 >/app/$4.out 2>&1 &

--- a/src/dunes/dunes.py
+++ b/src/dunes/dunes.py
@@ -99,18 +99,6 @@ class dunes:
             print("Node [" + nod.name() + "] is already running.")
             return
 
-        cmd = ['bash', 'start_node.sh', nod.data_dir(), nod.config_dir()]
-
-        if snapshot is not None:
-            cmd = cmd + ['--snapshot /app/nodes/' + nod.name() + '/snapshots/' + snapshot + ' -e']
-        else:
-            cmd = cmd + [' ']
-
-        if replay_blockchain is True:
-            cmd = cmd + ['--replay-blockchain']
-        else:
-            cmd = cmd + [' ']
-
         # if node name is not found we need to create it
         is_restart = True
         if not nod.name() in stdout:
@@ -132,7 +120,22 @@ class dunes:
 
         self.stop_conflicting_nodes(nod)
 
-        stdout, stderr, exit_code = self._docker.execute_cmd(cmd + [nod.name()])
+        cmd = ['bash', 'start_node.sh']
+        cmd = cmd + [nod.data_dir()]     # $1
+        cmd = cmd + [nod.config_dir()]   # $2
+        # $3
+        if snapshot is not None:
+            cmd = cmd + ['--snapshot /app/nodes/' + nod.name() + '/snapshots/' + snapshot + ' -e']
+        else:
+            cmd = cmd + [' ']
+        # $4
+        cmd = cmd + [nod.name()]
+        # $5
+        if replay_blockchain is True:
+            cmd = cmd + ['--replay-blockchain']
+        else:
+            cmd = cmd + [' ']
+        stdout, stderr, exit_code = self._docker.execute_cmd(cmd)
         print(stdout)
         print(stderr)
 


### PR DESCRIPTION
#172 allows for clearing a dirty DB; unfortunately we failed to consider backwards compatibility in the update.

Fixed by swapping the $4 and $5 arguments in the script and updating the caller inside dunes.

This allows an older DUNE executable to call a newer DUNES container image and vice versa.

Will close #226